### PR TITLE
unity and svc add new fouction

### DIFF
--- a/delfin/drivers/dell_emc/unity/rest_handler.py
+++ b/delfin/drivers/dell_emc/unity/rest_handler.py
@@ -35,6 +35,14 @@ class RestHandler(RestClient):
     REST_DEL_ALERTS_URL = '/api/instances/alert/'
     REST_LOGOUT_URL = '/api/types/loginSessionInfo/action/logout'
     AUTH_KEY = 'EMC-CSRF-TOKEN'
+    REST_CONTROLLER_URL = '/api/types/storageProcessor/instances'
+    REST_DISK_URL = '/api/types/disk/instances'
+    REST_FCPORT_URL = '/api/types/fcPort/instances'
+    REST_ETHPORT_URL = '/api/types/ethernetPort/instances'
+    REST_FILESYSTEM_URL = '/api/types/filesystem/instances'
+    REST_NFSSHARE_URL = '/api/types/nfsShare/instances'
+    REST_CIFSSHARE_URL = '/api/types/cifsShare/instances'
+    REST_QTREE_URL = '/api/types/treeQuota/instances'
     STATE_SOLVED = 2
 
     def __init__(self, **kwargs):
@@ -164,4 +172,66 @@ class RestHandler(RestClient):
         url = '%s%s/action/modify' % (RestHandler.REST_DEL_ALERTS_URL,
                                       alert_id)
         result_json = self.get_rest_info(url, data, method='POST')
+        return result_json
+
+    def get_all_controllers(self):
+        url = '%s?%s' % (RestHandler.REST_CONTROLLER_URL,
+                         'fields=id,name,health,model,slotNumber,'
+                         'emcPartNumber,emcSerialNumber,manufacturer,'
+                         'memorySize')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_disks(self):
+        url = '%s?%s' % (RestHandler.REST_DISK_URL,
+                         'fields=id,name,health,model,slotNumber,'
+                         'manufacturer,version,emcSerialNumber,wwn'
+                         'emcPartNumber,rpm,size,diskGroup')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_fcports(self):
+        url = '%s?%s' % (RestHandler.REST_FCPORT_URL,
+                         'fields=id,name,health,slotNumber,storageProcessor'
+                         'currentSpeed,availableSpeeds,wwn')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_ethports(self):
+        url = '%s?%s' % (RestHandler.REST_ETHPORT_URL,
+                         'fields=id,name,health,portNumber,storageProcessor'
+                         'speed,isLinkUp,macAddress,supportedSpeeds')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_port_interface(self):
+        url = '%s?%s' % (RestHandler.REST_ETHPORT_URL,
+                         'fields=id,ipPort,ipProtocolVersion,'
+                         'ipAddress,netmask')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_filesystems(self):
+        url = '%s?%s' % (RestHandler.REST_FILESYSTEM_URL,
+                         'fields=id,name,health,description,'
+                         'sizeTotal,sizeUsed,isThinEnabled,pool')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_nfsshares(self):
+        url = '%s?%s' % (RestHandler.REST_NFSSHARE_URL,
+                         'fields=id,filesystem,name,path')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_cifsshares(self):
+        url = '%s?%s' % (RestHandler.REST_CIFSSHARE_URL,
+                         'fields=id,filesystem,name,path')
+        result_json = self.get_rest_info(url)
+        return result_json
+
+    def get_all_qtrees(self):
+        url = '%s?%s' % (RestHandler.REST_QTREE_URL,
+                         'fields=id,filesystem,description,path')
+        result_json = self.get_rest_info(url)
         return result_json

--- a/delfin/drivers/ibm/storwize_svc/storwize_svc.py
+++ b/delfin/drivers/ibm/storwize_svc/storwize_svc.py
@@ -37,13 +37,13 @@ class StorwizeSVCDriver(driver.StorageDriver):
         return self.ssh_hanlder.list_volumes(self.storage_id)
 
     def list_controllers(self, context):
-        pass
+        return self.ssh_hanlder.list_controllers(self.storage_id)
 
     def list_ports(self, context):
-        pass
+        return self.ssh_hanlder.list_ports(self.storage_id)
 
     def list_disks(self, context):
-        pass
+        return self.ssh_hanlder.list_disks(self.storage_id)
 
     def list_alerts(self, context, query_para=None):
         return self.ssh_hanlder.list_alerts(query_para)


### PR DESCRIPTION
# Copyright 2021 The SODA Authors.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#   http:#www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
import six
from oslo_log import log

from delfin import exception
from delfin.common import constants
from delfin.drivers import driver
from delfin.drivers.dell_emc.unity import rest_handler, alert_handler
from delfin.drivers.dell_emc.unity.alert_handler import AlertHandler

LOG = log.getLogger(__name__)


class UnityStorDriver(driver.StorageDriver):
    """UnityStorDriver implement the DELL EMC Storage driver"""
    HEALTH_OK = (5, 7)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.rest_handler = rest_handler.RestHandler(**kwargs)
        self.rest_handler.login()

    def reset_connection(self, context, **kwargs):
        self.rest_handler.logout()
        self.rest_handler.verify = kwargs.get('verify', False)
        self.rest_handler.login()

    def close_connection(self):
        self.rest_handler.logout()

    def get_storage(self, context):
        system_info = self.rest_handler.get_storage()
        capacity = self.rest_handler.get_capacity()
        version_info = self.rest_handler.get_soft_version()
        status = constants.StorageStatus.OFFLINE
        if system_info is not None and capacity is not None:
            system_entries = system_info.get('entries')
            for system in system_entries:
                content = system.get('content', {})
                name = content.get('name')
                model = content.get('model')
                serial_number = content.get('serialNumber')
                health_value = content.get('health').get('value')
                if health_value in UnityStorDriver.HEALTH_OK:
                    status = constants.StorageStatus.NORMAL
                else:
                    status = constants.StorageStatus.ABNORMAL
                break
            capacity_info = capacity.get('entries')
            for per_capacity in capacity_info:
                content = per_capacity.get('content', {})
                free = content.get('sizeFree')
                total = content.get('sizeTotal')
                used = content.get('sizeUsed')
                subs = content.get('sizeSubscribed')
                break
            soft_version = version_info.get('entries')
            for soft_info in soft_version:
                content = soft_info.get('content', {})
                version = content.get('id')
                break
            system_result = {
                'name': name,
                'vendor': 'DELL EMC',
                'model': model,
                'status': status,
                'serial_number': serial_number,
                'firmware_version': version,
                'location': '',
                'subscribed_capacity': int(subs),
                'total_capacity': int(total),
                'raw_capacity': int(total),
                'used_capacity': int(used),
                'free_capacity': int(free)
            }
        return system_result

    def list_storage_pools(self, context):
        pool_info = self.rest_handler.get_all_pools()
        pool_list = []
        pool_type = constants.StorageType.UNIFIED
        if pool_info is not None:
            pool_entries = pool_info.get('entries')
            for pool in pool_entries:
                content = pool.get('content', {})
                health_value = content.get('health').get('value')
                if health_value in UnityStorDriver.HEALTH_OK:
                    status = constants.StorageStatus.NORMAL
                else:
                    status = constants.StorageStatus.ABNORMAL
                pool_result = {
                    'name': content.get('name'),
                    'storage_id': self.storage_id,
                    'native_storage_pool_id': str(content.get('id')),
                    'description': content.get('description'),
                    'status': status,
                    'storage_type': pool_type,
                    'total_capacity': int(content.get('sizeTotal')),
                    'subscribed_capacity': int(content.get('sizeSubscribed')),
                    'used_capacity': int(content.get('sizeUsed')),
                    'free_capacity': int(content.get('sizeFree'))
                }
                pool_list.append(pool_result)
        return pool_list

    def volume_handler(self, volumes, volume_list):
        if volumes is not None:
            vol_entries = volumes.get('entries')
            for volume in vol_entries:
                content = volume.get('content', {})
                total = content.get('sizeTotal')
                used = content.get('sizeAllocated')
                vol_type = constants.VolumeType.THICK
                if content.get('isThinEnabled') is True:
                    vol_type = constants.VolumeType.THIN
                health_value = content.get('health').get('value')
                if health_value in UnityStorDriver.HEALTH_OK:
                    status = constants.StorageStatus.NORMAL
                else:
                    status = constants.StorageStatus.ABNORMAL
                volume_result = {
                    'name': content.get('name'),
                    'storage_id': self.storage_id,
                    'description': content.get('description'),
                    'status': status,
                    'native_volume_id': str(content.get('id')),
                    'native_storage_pool_id': content.get('pool').get('id'),
                    'wwn': content.get('wwn'),
                    'type': vol_type,
                    'total_capacity': int(total),
                    'used_capacity': int(used),
                    'free_capacity': int(total - used)
                }
                volume_list.append(volume_result)

    def list_volumes(self, context):
        page_number = 1
        volume_list = []
        while True:
            luns = self.rest_handler.get_all_luns(page_number)
            if 'entries' not in luns:
                break
            if len(luns['entries']) < 1:
                break
            self.volume_handler(luns, volume_list)
            page_number = page_number + 1

        return volume_list

    def list_alerts(self, context, query_para=None):
        page_number = 1
        alert_model_list = []
        while True:
            alert_list = self.rest_handler.get_all_alerts(page_number)
            if 'entries' not in alert_list:
                break
            if len(alert_list['entries']) < 1:
                break
            alert_handler.AlertHandler() \
                .parse_queried_alerts(alert_model_list, alert_list, query_para)
            page_number = page_number + 1

        return alert_model_list

    def list_controllers(self, context):
        try:
            controller_list = []
            controller_info = self.rest_handler.get_all_controllers()
            if controller_info is not None:
                pool_entries = controller_info.get('entries')
                for pool in pool_entries:
                    content = pool.get('content', {})
                    health_value = content.get('health').get('value')
                    if health_value in UnityStorDriver.HEALTH_OK:
                        status = constants.StorageStatus.NORMAL
                    else:
                        status = constants.StorageStatus.ABNORMAL
                    controller_result = {
                        'name': content.get('name'),
                        'storage_id': self.storage_id,
                        'native_controller_id': content.get('id'),
                        'status': status,
                        'location': content.get('slotNumber'),
                        'memory_size': content.get('memorySize'),
                    }
                    controller_list.append(controller_result)
            return controller_list
        except Exception as err:
            err_msg = "Failed to get controller metrics from UnityStor: %s" %\
                      (six.text_type(err))
            LOG.error(err_msg)
            raise exception.InvalidResults(err_msg)

    @staticmethod
    def handle_port_ip(ip, result):
        if ip is None:
            ip = result
        else:
            ip = '%s;%s' % (ip, result)
        return ip

    def get_eth_ports(self, port_list):
        ports = self.rest_handler.get_all_ethports()
        ip_interfaces = self.rest_handler.get_port_interface()
        if ports is not None:
            port_entries = ports.get('entries')
            for port in port_entries:
                content = port.get('content', {})
                health_value = content.get('health').get('value')
                if health_value in UnityStorDriver.HEALTH_OK:
                    status = constants.StorageStatus.NORMAL
                else:
                    status = constants.StorageStatus.ABNORMAL
                conn_status = constants.PortConnectionStatus.CONNECTED if \
                    content.get('isLinkUp') is True \
                    else constants.PortConnectionStatus.DISCONNECTED
                ipv4 = None
                ipv4_mask = None
                ipv6 = None
                ipv6_mask = None
                for ip_info in ip_interfaces.get('entries'):
                    ip_content = ip_info.get('content', {})
                    if content.get('id') == ip_content.get(
                            'ipPort').get('id'):
                        if ip_content.get('ipProtocolVersion') == 4:
                            ipv4 = UnityStorDriver.handle_port_ip(
                                ipv4, ip_content.get('ipAddress'))
                            ipv4_mask = UnityStorDriver.handle_port_ip(
                                ipv4_mask, ip_content.get('netmask'))
                        else:
                            ipv6 = UnityStorDriver.handle_port_ip(
                                ipv6, ip_content.get('ipAddress'))
                            ipv6_mask = UnityStorDriver.handle_port_ip(
                                ipv6_mask, ip_content.get('netmask'))
                port_result = {
                    'name': content.get('name'),
                    'storage_id': self.storage_id,
                    'native_port_id': content.get('id'),
                    'location': content.get('name'),
                    'connection_status': conn_status,
                    'health_status': status,
                    'type': constants.PortType.ETH,
                    'logical_type': '',
                    'speed': content.get('speed'),
                    'max_speed': content.get('maxMtu'),
                    'native_parent_id':
                        content.get('storageProcessor').get('id'),
                    'wwn': '',
                    'mac_address': content.get('macAddress'),
                    'ipv4': ipv4,
                    'ipv4_mask': ipv4_mask,
                    'ipv6': ipv6,
                    'ipv6_mask': ipv6_mask
                }
                port_list.append(port_result)

    def get_fc_port(self, port_list):
        ports = self.rest_handler.get_all_fcports()
        if ports is not None:
            port_entries = ports.get('entries')
            for port in port_entries:
                content = port.get('content', {})
                health_value = content.get('health').get('value')
                if health_value in UnityStorDriver.HEALTH_OK:
                    status = constants.StorageStatus.NORMAL
                else:
                    status = constants.StorageStatus.ABNORMAL
                conn_status = status
                port_result = {
                    'name': content.get('name'),
                    'storage_id': self.storage_id,
                    'native_port_id': content.get('id'),
                    'location': content.get('slotNumber'),
                    'connection_status': conn_status,
                    'health_status': status,
                    'type': constants.PortType.FC,
                    'logical_type': '',
                    'speed': content.get('currentSpeed'),
                    'max_speed': content.get('requestedSpeed'),
                    'native_parent_id':
                        content.get('storageProcessor').get('id'),
                    'wwn': content.get('wwn'),
                    'mac_address': '',
                    'ipv4': '',
                    'ipv4_mask': '',
                    'ipv6': '',
                    'ipv6_mask': ''
                }
                port_list.append(port_result)

    def list_ports(self, context):
        try:
            port_list = []
            self.get_eth_ports(port_list)
            self.get_fc_port(port_list)
            return port_list
        except Exception as err:
            err_msg = "Failed to get ports metrics from UnityStor: %s" % \
                      (six.text_type(err))
            raise exception.InvalidResults(err_msg)

    def list_disks(self, context):
        try:
            disks = self.rest_handler.get_all_disks()
            disk_list = []
            if disks is not None:
                disk_entries = disks.get('entries')
                for disk in disk_entries:
                    content = disk.get('content', {})
                    health_value = content.get('health').get('value')
                    if health_value in UnityStorDriver.HEALTH_OK:
                        status = constants.StorageStatus.NORMAL
                    else:
                        status = constants.StorageStatus.ABNORMAL
                    disk_result = {
                        'name': content.get('name'),
                        'storage_id': self.storage_id,
                        'native_disk_id': content.get('id'),
                        'serial_number': content.get('emcSerialNumber'),
                        'manufacturer': content.get('manufacturer'),
                        'model': content.get('model'),
                        'firmware': content.get('version'),
                        'speed': content.get('rpm'),
                        'capacity': content.get('size'),
                        'status': status,
                        'physical_type': constants.DiskPhysicalType.SAS,
                        'logical_type': '',
                        'native_disk_group_id': content.
                            get('diskGroup').get('id'),
                        'location': content.get('slotNumber')
                    }
                    disk_list.append(disk_result)
            return disk_list

        except Exception as err:
            err_msg = "Failed to get disk metrics from UnityStor: %s" % \
                      (six.text_type(err))
            raise exception.InvalidResults(err_msg)

    def list_filesystems(self, context):
        try:
            files = self.rest_handler.get_all_filesystems()
            fs_list = []
            if files is not None:
                fs_entries = files.get('entries')
                for file in fs_entries:
                    content = file.get('content', {})
                    health_value = content.get('health').get('value')
                    if health_value in UnityStorDriver.HEALTH_OK:
                        status = constants.StorageStatus.NORMAL
                    else:
                        status = constants.StorageStatus.ABNORMAL
                    fs_type = constants.VolumeType.THICK
                    if content.get('isThinEnabled') is True:
                        fs_type = constants.VolumeType.THIN
                    fs = {
                        'name': content.get('name'),
                        'storage_id': self.storage_id,
                        'native_filesystem_id': content.get('id'),
                        'native_pool_id': content.get('pool').get('id'),
                        'status': status,
                        'type': fs_type,
                        'total_capacity': int(content.get('sizeTotal')),
                        'used_capacity': int(content.get('sizeAllocated')),
                        'free_capacity': int(content.get('sizeTotal')) - int(
                            content.get('sizeAllocated'))
                    }
                    fs_list.append(fs)
            return fs_list
        except Exception as err:
            err_msg = "Failed to get filesystem metrics from UnityStor: %s"\
                      % (six.text_type(err))
            raise exception.InvalidResults(err_msg)

    def list_qtrees(self, context):
        try:
            qts = self.rest_handler.get_all_qtrees()
            qt_list = []
            if qts is not None:
                qts_entries = qts.get('entries')
                for qtree in qts_entries:
                    content = qtree.get('content', {})
                    qt = {
                        'name': content.get('description'),
                        'storage_id': self.storage_id,
                        'native_qtree_id': content.get('id'),
                        'native_filesystem_id':
                            content.get('filesystem').get('id'),
                        'path': content.get('path')
                    }
                    qt_list.append(qt)
            return qt_list
        except Exception as err:
            err_msg = "Failed to get qtree metrics from UnityStor: %s"\
                      % (six.text_type(err))
            raise exception.InvalidResults(err_msg)

    def get_share(self, share_list, protocol):
        try:
            if protocol == 'cifs':
                shares = self.rest_handler.get_all_cifsshares()
                protocol = constants.ShareProtocol.CIFS
            else:
                shares = self.rest_handler.get_all_nfsshares()
                protocol = constants.ShareProtocol.NFS
            if shares is not None:
                share_entries = shares.get('entries')
                for share in share_entries:
                    content = share.get('content', {})
                    fs = {
                        'name': content.get('name'),
                        'storage_id': self.storage_id,
                        'native_share_id': content.get('id'),
                        'native_filesystem_id':
                            content.get('filesystem').get('id'),
                        'path': content.get('path'),
                        'protocol': protocol
                    }
                    share_list.append(fs)
        except Exception as err:
            err_msg = "Failed to get share metrics from UnityStor: %s"\
                      % (six.text_type(err))
            raise exception.InvalidResults(err_msg)

    def list_shares(self, context):
        try:
            share_list = []
            self.get_share(share_list, 'cifs')
            self.get_share(share_list, 'nfs')
            return share_list
        except Exception as err:
            err_msg = "Failed to get shares metrics from UnityStor: %s"\
                      % (six.text_type(err))
            raise exception.InvalidResults(err_msg)

    def add_trap_config(self, context, trap_config):
        pass

    def remove_trap_config(self, context, trap_config):
        pass

    @staticmethod
    def parse_alert(context, alert):
        return AlertHandler.parse_alert(context, alert)

    def clear_alert(self, context, alert):
        return self.rest_handler.remove_alert(alert)

    @staticmethod
    def get_access_url():
        return 'https://{ip}'







# Copyright 2021 The SODA Authors.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#   http:#www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
import threading

import requests
import six
from oslo_log import log as logging

# from delfin import cryptor
from delfin import exception
from delfin.drivers.utils.rest_client import RestClient

LOG = logging.getLogger(__name__)


class RestHandler(RestClient):
    REST_AUTH_URL = '/api/types/loginSessionInfo/instances'
    REST_STORAGE_URL = '/api/types/system/instances'
    REST_CAPACITY_URL = '/api/types/systemCapacity/instances'
    REST_SOFT_VERSION_URL = '/api/types/installedSoftwareVersion/instances'
    REST_LUNS_URL = '/api/types/lun/instances'
    REST_POOLS_URL = '/api/types/pool/instances'
    REST_ALERTS_URL = '/api/types/alert/instances'
    REST_DEL_ALERTS_URL = '/api/instances/alert/'
    REST_LOGOUT_URL = '/api/types/loginSessionInfo/action/logout'
    AUTH_KEY = 'EMC-CSRF-TOKEN'
    REST_CONTROLLER_URL = '/api/types/storageProcessor/instances'
    REST_DISK_URL = '/api/types/disk/instances'
    REST_FCPORT_URL = '/api/types/fcPort/instances'
    REST_ETHPORT_URL = '/api/types/ethernetPort/instances'
    REST_IP_URL = '/api/types/ipInterface/instances'
    REST_FILESYSTEM_URL = '/api/types/filesystem/instances'
    REST_NFSSHARE_URL = '/api/types/nfsShare/instances'
    REST_CIFSSHARE_URL = '/api/types/cifsShare/instances'
    REST_QTREE_URL = '/api/types/treeQuota/instances'
    STATE_SOLVED = 2

    def __init__(self, **kwargs):
        super(RestHandler, self).__init__(**kwargs)
        self.session_lock = threading.Lock()

    def login(self):
        """Login dell_emc unity storage array."""
        try:
            with self.session_lock:
                data = {}
                if self.session is None:
                    self.init_http_head()
                self.session.headers.update({"X-EMC-REST-CLIENT": "true"})
                self.session.auth = requests.auth.HTTPBasicAuth(
                    # self.rest_username, cryptor.decode(self.rest_password))
                    self.rest_username, self.rest_password)
                res = self.call_with_token(
                    RestHandler.REST_AUTH_URL, data, 'GET')
                if res.status_code == 200:
                    self.session.headers[RestHandler.AUTH_KEY] = res.headers[RestHandler.AUTH_KEY]
                        # cryptor.encode(res.headers[RestHandler.AUTH_KEY])

                else:
                    LOG.error("Login error.URL: %s,Reason: %s.",
                              RestHandler.REST_AUTH_URL, res.text)
                    if 'Unauthorized' in res.text:
                        raise exception.InvalidUsernameOrPassword()
                    elif 'Forbidden' in res.text:
                        raise exception.InvalidIpOrPort()
                    else:
                        raise exception.StorageBackendException(
                            six.text_type(res.text))
        except Exception as e:
            LOG.error("Login error: %s", six.text_type(e))
            raise e

    def call_with_token(self, url, data, method):
        auth_key = None
        if self.session:
            auth_key = self.session.headers.get(RestHandler.AUTH_KEY, None)
            if auth_key:
                self.session.headers[RestHandler.AUTH_KEY] = auth_key
                    # = cryptor.decode(auth_key)

        res = self.do_call(url, data, method)
        if auth_key:
            self.session.headers[RestHandler.AUTH_KEY] = auth_key
        return res

    def logout(self):
        try:
            if self.san_address:
                self.call(RestHandler.REST_LOGOUT_URL, method='POST')
            if self.session:
                self.session.close()
        except Exception as e:
            err_msg = "Logout error: %s" % (six.text_type(e))
            LOG.error(err_msg)
            raise e

    def get_rest_info(self, url, data=None, method='GET'):
        result_json = None
        res = self.call(url, data, method)
        if res.status_code == 200:
            result_json = res.json()
        return result_json

    def call(self, url, data=None, method=None):
        try:
            res = self.call_with_token(url, data, method)
            if res.status_code == 401:
                LOG.error("Failed to get token, status_code:%s,error_mesg:%s" %
                          (res.status_code, res.text))
                self.login()
                res = self.call_with_token(url, data, method)
            elif res.status_code == 503:
                raise exception.InvalidResults(res.text)
            return res
        except Exception as e:
            LOG.error("Method:%s,url:%s failed: %s" % (method, url,
                                                       six.text_type(e)))
            raise e

    def get_all_pools(self):
        url = '%s?%s' % (RestHandler.REST_POOLS_URL,
                         'fields=id,name,health,type,sizeFree,'
                         'sizeTotal,sizeUsed,sizeSubscribed')
        result_json = self.get_rest_info(url)
        return result_json

    def get_storage(self):
        url = '%s?%s' % (RestHandler.REST_STORAGE_URL,
                         'fields=name,model,serialNumber,health')
        result_json = self.get_rest_info(url)
        return result_json

    def get_capacity(self):
        url = '%s?%s' % (RestHandler.REST_CAPACITY_URL,
                         'fields=sizeFree,sizeTotal,sizeUsed,'
                         'sizeSubscribed,totalLogicalSize')
        result_json = self.get_rest_info(url)
        return result_json

    def get_soft_version(self):
        url = '%s?%s' % (RestHandler.REST_SOFT_VERSION_URL,
                         'fields=version')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_luns(self, page_number):
        url = '%s?%s&page=%s' % (RestHandler.REST_LUNS_URL,
                                 'fields=id,name,health,type,sizeAllocated,'
                                 'sizeTotal,sizeUsed,pool,wwn,isThinEnabled',
                                 page_number)
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_alerts(self, page_number):
        url = '%s?%s&page=%s' % (RestHandler.REST_ALERTS_URL,
                                 'fields=id,timestamp,severity,component,'
                                 'messageId,message,description,'
                                 'descriptionId,state',
                                 page_number)
        result_json = self.get_rest_info(url)
        return result_json

    def remove_alert(self, alert_id):
        data = {"state": RestHandler.STATE_SOLVED}
        url = '%s%s/action/modify' % (RestHandler.REST_DEL_ALERTS_URL,
                                      alert_id)
        result_json = self.get_rest_info(url, data, method='POST')
        return result_json

    def get_all_controllers(self):
        url = '%s?%s' % (RestHandler.REST_CONTROLLER_URL,
                         'fields=id,name,health,model,slotNumber,'
                         'emcPartNumber,emcSerialNumber,manufacturer,'
                         'memorySize')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_disks(self):
        url = '%s?%s' % (RestHandler.REST_DISK_URL,
                         'fields=id,name,health,model,slotNumber,'
                         'manufacturer,version,emcSerialNumber,wwn'
                         'emcPartNumber,rpm,size,diskGroup')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_fcports(self):
        url = '%s?%s' % (RestHandler.REST_FCPORT_URL,
                         'fields=id,name,health,slotNumber,storageProcessor,'
                         'currentSpeed,requestedSpeed,wwn')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_ethports(self):
        url = '%s?%s' % (RestHandler.REST_ETHPORT_URL,
                         'fields=id,name,health,portNumber,storageProcessor,'
                         'speed,isLinkUp,macAddress,maxMtu')
        result_json = self.get_rest_info(url)
        return result_json

    def get_port_interface(self):
        url = '%s?%s' % (RestHandler.REST_IP_URL,
                         'fields=id,ipPort,ipProtocolVersion,'
                         'ipAddress,netmask')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_filesystems(self):
        url = '%s?%s' % (RestHandler.REST_FILESYSTEM_URL,
                         'fields=id,name,health,sizeAllocated,'
                         'sizeTotal,sizeUsed,isThinEnabled,pool')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_nfsshares(self):
        url = '%s?%s' % (RestHandler.REST_NFSSHARE_URL,
                         'fields=id,filesystem,name,path')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_cifsshares(self):
        url = '%s?%s' % (RestHandler.REST_CIFSSHARE_URL,
                         'fields=id,filesystem,name,path')
        result_json = self.get_rest_info(url)
        return result_json

    def get_all_qtrees(self):
        url = '%s?%s' % (RestHandler.REST_QTREE_URL,
                         'fields=id,filesystem,description,path')
        result_json = self.get_rest_info(url)
        return result_json
